### PR TITLE
fix: typo in "external-ressources"

### DIFF
--- a/updxvk
+++ b/updxvk
@@ -359,7 +359,7 @@ if [ "$1" == "proton-tkg" ]; then
       if [ "$_proton_tkg_path" = "proton-tkg" ]; then
         _proton_tkg_path=".."
       else
-        _proton_tkg_path="../wine-tkg-git/proton-tkg/external-ressources"
+        _proton_tkg_path="../wine-tkg-git/proton-tkg/external-resources"
       fi
 
       rm -rf "$_proton_tkg_path"/dxvk


### PR DESCRIPTION
Currently using the PKGBUILDS repo with submodules reset and updated via TkgThingy, the `updxvk` script will copy its results into `../wine-tkg-git/proton-tkg/external-ressources`, but the `external-ressources` folder should be `external-resources` instead

_proton_tkg_path changed: "external-ressources" -> "external-resources"
